### PR TITLE
Improve parsing of SentencePiece file

### DIFF
--- a/onmt_tools.py
+++ b/onmt_tools.py
@@ -48,10 +48,10 @@ def sp_vocab_to_onmt_vocab(sp_vocab, onmt_vocab):
         with open(onmt_vocab, 'wb') as fout:
             OMIT = (DefaultTokens.UNK, DefaultTokens.BOS, DefaultTokens.EOS)
             for line in fin:
-                line_and_freq = line.rstrip("\n").split(None, 1)
-                if len(line_and_freq) != 2:
+                token_and_freq = line.rstrip("\n").split(None, 1)
+                if len(token_and_freq) != 2:
                     continue
-                w, c = line_and_freq
+                w, c = token_and_freq
                 if w in OMIT:
                     continue
                 c = math.exp(float(c)) * 1000000

--- a/onmt_tools.py
+++ b/onmt_tools.py
@@ -48,7 +48,10 @@ def sp_vocab_to_onmt_vocab(sp_vocab, onmt_vocab):
         with open(onmt_vocab, 'wb') as fout:
             OMIT = (DefaultTokens.UNK, DefaultTokens.BOS, DefaultTokens.EOS)
             for line in fin:
-                w, c = line.rstrip("\n").split(None, 1)
+                line_and_freq = line.rstrip("\n").split(None, 1)
+                if len(line_and_freq) != 2:
+                    continue
+                w, c = line_and_freq
                 if w in OMIT:
                     continue
                 c = math.exp(float(c)) * 1000000


### PR DESCRIPTION
When there is whitespace in the SentencePiece
token value the Python `strip` function fails.

- https://github.com/argosopentech/OpenNMT-py/commit/5515c93cb6e9e9bbc7bcaf71e87ae7af0d30b1ef
- https://community.libretranslate.com/t/odd-translation-behavior-repeating-words/827/8
- https://forum.opennmt.net/t/valueerror-not-enough-values-to-unpack-expected-2-got-1/4220/5
- https://forum.opennmt.net/t/opennmt-py-error-when-training-with-large-amount-of-data/4310/22