### PR TITLE
Added "excerpt" filter

### DIFF
--- a/FILTERS.md
+++ b/FILTERS.md
@@ -29,9 +29,9 @@ is greather than max.
 <code>Remove lines when source is the same as target</code>
 
 #### excerpt
-<code>Selects the part of a corpus located between top % and bottom % of the whole data (useful with very large corpora only).</code>
-* top (float) : percentage of the corpus where data collection begins
-* bottom (float) : percentage at which data collection ends
+<code>Selects a partial dataset located between top % and bottom % of a large dataset (useful with very large ones).</code>
+* top_percentile (float) : dataset percentile where data collection begins
+* bottom_percentile (float) : percentile where data collection ends
   
 #### first_char_mismatch
 <code>Removes lines when the first character is a letter but the case is mismatched, or the first character in source is not the same as the first character in target.</code>

--- a/FILTERS.md
+++ b/FILTERS.md
@@ -9,7 +9,7 @@
 #### characters_count_mismatch
 <code>Removes lines when the sum of certain characters between source and target is not the same.
 </code>
- * chars (str) : Characters to check (()[]?!:."ìî{})
+ * chars (str) : Characters to check (()[]?!:."‚Äú‚Äù{})
 
 #### contains
 <code>Removes lines that contain these words
@@ -28,6 +28,11 @@ is greather than max.
 #### duplicates
 <code>Remove lines when source is the same as target</code>
 
+#### excerpt
+<code>Selects the part of a corpus located between top % and bottom % of the whole data (useful with very large corpora only).</code>
+* top (float) : percentage of the corpus where data collection begins
+* bottom (float) : percentage at which data collection ends
+  
 #### first_char_mismatch
 <code>Removes lines when the first character is a letter but the case is mismatched, or the first character in source is not the same as the first character in target.</code>
 

--- a/data.py
+++ b/data.py
@@ -316,7 +316,8 @@ def merge_shuffle(sources, out_dir, max_eval_sentences=5000, remove_duplicates=T
                 # Skip top % if excerpt filter on
                 if begin_at is not None and count <= begin_at
                     continue
-                
+
+                #Exits if excerpt or top filter on
                 if stop_at is not None and count >= stop_at:
                     break
 

--- a/data.py
+++ b/data.py
@@ -314,7 +314,7 @@ def merge_shuffle(sources, out_dir, max_eval_sentences=5000, remove_duplicates=T
 
             for src_line in src_it:
                 # Skip top % if excerpt filter on
-                if begin_at is not None and count <= begin_at
+                if begin_at is not None and count <= begin_at:
                     continue
 
                 #Exits if excerpt or top filter on

--- a/data.py
+++ b/data.py
@@ -286,6 +286,7 @@ def merge_shuffle(sources, out_dir, max_eval_sentences=5000, remove_duplicates=T
         filtered = {}
         count = 0
         augmented = 0
+        begin_at = None
         stop_at = None
         line_count = None
 
@@ -296,6 +297,14 @@ def merge_shuffle(sources, out_dir, max_eval_sentences=5000, remove_duplicates=T
                 stop_at = int((f.__args__.get("percent", 100) / 100) * line_count)
                 print(f"Stop at: {stop_at}")
 
+            if f.__name__ == "excerpt":
+                line_count = count_lines(source)
+                print(f"Line count: {line_count}")
+                begin_at = int((f.__args__.get("top", 100) / 100) * line_count)
+                print(f"Begins collecting at: {begin_at}")
+                stop_at = int((f.__args__.get("bottom", 100) / 100) * line_count)
+                print(f"Ends collecting at: {stop_at}")
+
         with open(source, "r+b") as src_fp, \
              open(target, "r+b") as tgt_fp:
             src_mm = mmap.mmap(src_fp.fileno(), 0)
@@ -304,6 +313,10 @@ def merge_shuffle(sources, out_dir, max_eval_sentences=5000, remove_duplicates=T
             tgt_it = iter(tgt_mm.readline, b"")
 
             for src_line in src_it:
+                # Skip top % if excerpt filter on
+                if begin_at is not None and count <= begin_at
+                    continue
+                
                 if stop_at is not None and count >= stop_at:
                     break
 

--- a/data.py
+++ b/data.py
@@ -300,9 +300,9 @@ def merge_shuffle(sources, out_dir, max_eval_sentences=5000, remove_duplicates=T
             if f.__name__ == "excerpt":
                 line_count = count_lines(source)
                 print(f"Line count: {line_count}")
-                begin_at = int((f.__args__.get("top", 100) / 100) * line_count)
+                begin_at = int((f.__args__.get("top_percentile", 100) / 100) * line_count)
                 print(f"Begins collecting at: {begin_at}")
-                stop_at = int((f.__args__.get("bottom", 100) / 100) * line_count)
+                stop_at = int((f.__args__.get("bottom_percentile", 100) / 100) * line_count)
                 print(f"Ends collecting at: {stop_at}")
 
         with open(source, "r+b") as src_fp, \

--- a/data.py
+++ b/data.py
@@ -317,7 +317,7 @@ def merge_shuffle(sources, out_dir, max_eval_sentences=5000, remove_duplicates=T
                 if begin_at is not None and count <= begin_at:
                     continue
 
-                #Exits if excerpt or top filter on
+                #Exit point if excerpt or top filter on
                 if stop_at is not None and count >= stop_at:
                     break
 

--- a/filters.py
+++ b/filters.py
@@ -1,3 +1,12 @@
+def excerpt(src, tgt, top, bottom):
+    """
+    Only add the lines between top X% and botom Y% from the dataset
+
+    :param float top: Percentage of dataset to begin collection
+    :param float bottom: Percentage of dataset to end collection
+    """
+    return False # placeholder
+
 def top(src, tgt, percent):
     """
     Only add the top X% lines from the dataset

--- a/filters.py
+++ b/filters.py
@@ -1,9 +1,9 @@
-def excerpt(src, tgt, top, bottom):
+def excerpt(src, tgt, top_percentile, bottom_percentile):
     """
     Only add the lines between top X% and botom Y% from the dataset
 
-    :param float top: Percentage of dataset to begin collection
-    :param float bottom: Percentage of dataset to end collection
+    :param float top_percentile: Percentile of dataset where collection begins
+    :param float bottom_percentile: Percentile of dataset where collection stops
     """
     return False # placeholder
 


### PR DESCRIPTION
This filter allows for filtering a corpus between the "top_percentile" and the "bottom_percentile" data. 

_Useful for CCMatrix or NLLB corpora where data is sorted using LASER scores and top 10% consists in short, easy sentences._