### PR TITLE
Fixed the default batch_size in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The output will be saved in `run/[model]/translate-[from]_[to]-[version].argosmo
 
 ### Running out of memory
 
-If you're running out of CUDA memory, decrease the `batch_size` parameter, which by default is set to `4096`:
+If you're running out of CUDA memory, decrease the `batch_size` parameter, which by default is set to `8192`:
 
 ```json
 {


### PR DESCRIPTION
The batch_size was changed in this commit: https://github.com/LibreTranslate/Locomotive/commit/15261dde96cdaffce528a4004d052c7a78bc5899
However, this change wasn't reflected in the readme yet.