### PR TITLE
Added translation of flores to file (for COMET-22 eval) and choice of flores dataset (between dev and devtest)

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -101,8 +101,6 @@ data = translator()
 if args.bleu or args.flores_id or args.translate_flores is not None:
     if args.flores_dataset:
         dataset = args.flores_dataset
-    else: 
-        dataset = "dev"
     src_text = get_flores(config["from"]["code"], dataset)
     tgt_text = get_flores(config["to"]["code"], dataset)
     
@@ -133,6 +131,7 @@ if args.bleu or args.flores_id or args.translate_flores is not None:
         print(f"({config['from']['code']})> {src_text[0]}\n(gt)> {tgt_text[0]}\n({config['to']['code']})> {' '.join(translated_text)}")
     else:
         print(f"BLEU score: {bleu_score}")
+
 else:
     # Interactive mode
     print("Starting interactive mode")

--- a/eval.py
+++ b/eval.py
@@ -25,6 +25,13 @@ parser.add_argument('--flores-id',
 parser.add_argument('--tokens',
     action="store_true",
     help='Display tokens rather than words. Default: %(default)s')
+parser.add_argument('--flores_dataset',
+    type=str,
+    default="dev",
+    help='Defines the flores200 dataset to translate. Default: %(default)s')
+parser.add_argument('--translate_flores',
+    action="store_true",
+    help='Translate the flores200 corpus into a text file with .evl extension. Default: %(default)s')
 parser.add_argument('--cpu',
     action="store_true",
     help='Force CPU use. Default: %(default)s')
@@ -80,11 +87,24 @@ def decode(tokens, tokenizer):
             detokenized = detokenized[1:]
         return detokenized
 
+def translate_flores():
+    tra_filename = f"flores200{dataset}-{model_dirname}.evl"
+    tra_f = os.path.join(run_dir, tra_filename)
+    with open(tra_f, "w", encoding="utf8") as translation_file:
+        for t in translated_text:
+            translation_file.write(t)
+            translation_file.write("\n")
+    return tra_f
+
 data = translator()
 
-if args.bleu or args.flores_id is not None:
-    src_text = get_flores(config["from"]["code"], "dev")
-    tgt_text = get_flores(config["to"]["code"], "dev")
+if args.bleu or args.flores_id or args.translate_flores is not None:
+    if args.flores_dataset:
+        dataset = args.flores_dataset
+    else: 
+        dataset = "dev"
+    src_text = get_flores(config["from"]["code"], dataset)
+    tgt_text = get_flores(config["to"]["code"], dataset)
     
     if args.flores_id is not None:
         src_text = [src_text[args.flores_id]]
@@ -105,6 +125,9 @@ if args.bleu or args.flores_id is not None:
     bleu_score = round(corpus_bleu(
         translated_text, [[x] for x in tgt_text]
     ).score, 5)
+
+    if args.translate_flores:
+        translate_flores()
 
     if args.flores_id is not None:
         print(f"({config['from']['code']})> {src_text[0]}\n(gt)> {tgt_text[0]}\n({config['to']['code']})> {' '.join(translated_text)}")


### PR DESCRIPTION
The current modification adds two arguments to the eval.py module :
1. --flores_dataset allows using either of the two "dev" and "devtest" flores200 datasets : 

- although dev is useful when experimenting, (I'll tell more in a subsequent post to the community), the dataset featuring in all mainstream evaluation is "devtest"
- for now, "dev" is default value, it is set at line 30

3. --translate_flores will have the model corresponding to the "--config" argument translate the flores200 (specified or default) dataset into a "flores200{dataset}-{from}_{to}-{version}.evl" file in the running directory

This file can be used for evaluation with the COMET-22 tool or any other one might think of (can be fed to chatGPT as well;-). 