### PR TITLE
comet evaluation in eval.py

### DIFF
--- a/data.py
+++ b/data.py
@@ -197,6 +197,11 @@ def get_flores_dataset_path(dataset="dev"):
 
     return flores_dataset
 
+def get_flores_file_path(lang_code, dataset="dev"):
+    flores_dataset = get_flores_dataset_path(dataset)
+    flores_file_path = os.path.join(flores_dataset, nllb_langs[lang_code] + f".{dataset}")
+    return flores_file_path
+
 def get_flores(lang_code, dataset="dev"):
     flores_dataset = get_flores_dataset_path(dataset)
     source = os.path.join(flores_dataset, nllb_langs[lang_code] + f".{dataset}")


### PR DESCRIPTION
Added 
- a function in data.py that returns the flores datset source or reference file path
- a --comet option in eval.py that gets the source and reference file paths, translates the source using the model specified in the config argument and the dataset specified in the "flores_dataset" argument (default= dev), and computes a COMET-22 score for said model and dataset.