### PR TITLE
COMET evaluation in eval.py

### DIFF
--- a/data.py
+++ b/data.py
@@ -197,6 +197,11 @@ def get_flores_dataset_path(dataset="dev"):
 
     return flores_dataset
 
+def get_flores_file_path(lang_code, dataset="dev"):
+    flores_dataset = get_flores_dataset_path(dataset)
+    flores_file_path = os.path.join(flores_dataset, nllb_langs[lang_code] + f".{dataset}")
+    return flores_file_path
+
 def get_flores(lang_code, dataset="dev"):
     flores_dataset = get_flores_dataset_path(dataset)
     source = os.path.join(flores_dataset, nllb_langs[lang_code] + f".{dataset}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ sentencepiece==0.1.99
 requests==2.31.0
 PyYAML==6.0.1
 sacrebleu==2.3.1
+unbabel-comet==2.2.2
 subword-nmt>=0.3.7
 OpenNMT-py==3.4.1
 tensorboard==2.14.0


### PR DESCRIPTION
1. Requirements.txt includes unbabel-comet 2.2.2 for clean install of COMET models
2. Data.py includes a method to return flores200 file paths to eval.py
3. Eval.py includes a "--comet" option, the option will launch COMET score for the language pair specified in the "--config" argument, using the source and reference files in flores200 directory, and an on-the-fly translation in the running directory, obtained with the translate_flores method introduced in PR #23.
4. Flores200 dataset to be scored against can be specified with the already existing flores_dataset option

Installing COMET also allows using (with CLI) the "comet-compare" function to compare models that use different hyperparameters or training data.