### PR TITLE
Advanced filters, versatile SBD, updated NLLB list, eval with pivot and translation memoirs, byte-fallback and advanced transformers

### DIFF
--- a/FILTERS.md
+++ b/FILTERS.md
@@ -50,9 +50,13 @@ then, save it in the ./cache/fasttext/ directory.
   journal={arXiv preprint arXiv:1607.01759},
   year={2016}
 }</code>
-  
+
 #### first_char_mismatch
 <code>Removes lines when the first character is a letter but the case is mismatched, or the first character in source is not the same as the first character in target.</code>
+
+#### limit_latin_chars
+<code>Removes lines when the number of latin characters exceeds max. Useful with some corpora that exhibit mixed charsets in sentences when useful charset isn't "Latn".</code>
+  * max (int) : Maximum count (12)
 
 #### nonalphanum_count_mismatch
 <code>Removes lines when the sum of non-alphanumeric characters (except spaces) between source and target is not the same</code>

--- a/FILTERS.md
+++ b/FILTERS.md
@@ -32,6 +32,24 @@ is greather than max.
 <code>Selects a partial dataset located between top % and bottom % of a large dataset (useful with very large ones).</code>
 * top_percentile (float) : dataset percentile where data collection begins
 * bottom_percentile (float) : percentile where data collection ends
+
+#### fast_lang
+<code>Removes lines written in other languages than the ones specified for training. 
+To use it, you need to download fasttext model for language identification first ; 
+then, save it in the ./cache/fasttext/ directory.
+</code>
+* lid.176.bin from https://fasttext.cc/docs/en/language-identification.html
+
+<mark>_Please note that fast text is distributed under CC-BY-SA 3.0 licence._</mark>
+
+<mark>Credits: A. Joulin, E. Grave, P. Bojanowski, T. Mikolov, Bag of Tricks for Efficient Text Classification</mark>
+
+<code>@article{joulin2016bag,
+  title={Bag of Tricks for Efficient Text Classification},
+  author={Joulin, Armand and Grave, Edouard and Bojanowski, Piotr and Mikolov, Tomas},
+  journal={arXiv preprint arXiv:1607.01759},
+  year={2016}
+}</code>
   
 #### first_char_mismatch
 <code>Removes lines when the first character is a letter but the case is mismatched, or the first character in source is not the same as the first character in target.</code>

--- a/README.md
+++ b/README.md
@@ -210,6 +210,17 @@ You can also compute [BLEU](https://en.wikipedia.org/wiki/BLEU) scores against t
 python eval.py --config config.json --bleu
 BLEU score: 45.12354
 ```
+You can also compute [COMET-22](https://github.com/Unbabel/COMET) scores against the [flores200](https://github.com/facebookresearch/flores/blob/main/flores200/README.md) dataset for the model by running:
+```bash
+python eval.py --config config.json --comet --bleu
+Fetching 5 files: 100%|██████████████████████████████████████████████████████████████████████████| 5/5 [00:00<?, ?it/s]
+....\pytorch_lightning\core\saving.py:195: Found keys that are not in the model state dict but in the checkpoint: ['encoder.model.embeddings.position_ids']
+....\flores200devtest-.....evl score: 0.8003
+BLEU score: 27.44794
+```
+You can also install further COMET models [AfriCOMET](https://github.com/masakhane-io/africomet) and update the script to use them.
+
+<mark>Unzip the necessary Argos package(s) into the "utils" directory first prior to using arg --pivot to evaluate a composite translation (i.e. to or from a third language).</mark>
 
 ## Convert Helsinki-NLP OPUS MT models
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ BLEU score: 27.44794
 ```
 You can also install further COMET models [AfriCOMET](https://github.com/masakhane-io/africomet) and update the script to use them.
 
-<mark>Unzip the necessary Argos package(s) into the "utils" directory first prior to using arg --pivot to evaluate a composite translation (i.e. to or from a third language).</mark>
+<mark>Unzip the necessary Argos package(s) to the "utils" directory before using arg --pivot to evaluate a composite translation</mark> (i.e. to or from a third language).
 
 ## Convert Helsinki-NLP OPUS MT models
 

--- a/data.py
+++ b/data.py
@@ -319,8 +319,10 @@ def merge_shuffle(sources, out_dir, max_eval_sentences=5000, remove_duplicates=T
         nonlocal total_count
         source = sources[k]['source']
         src_lang = sources[k]['from']
+        src_chset = nllb_langs[src_lang][-4:]
         target = sources[k]['target']
         tgt_lang = sources[k]['to']
+        tgt_chset = nllb_langs[tgt_lang][-4:]
         if sources[k]['weight'] is not None:
             return
         
@@ -334,6 +336,8 @@ def merge_shuffle(sources, out_dir, max_eval_sentences=5000, remove_duplicates=T
                 def get_func(name):
                     kwargs = dict(f[name])
                     func = getattr(filter_funcs, name)
+                    if name == 'limit_latin_chars':
+                        kwargs = {"s_chset": src_chset, "t_chset": tgt_chset, **kwargs}
                     lam = lambda src, tgt: func(src, tgt, **kwargs)
                     lam.__name__ = name
                     lam.__args__ = kwargs
@@ -464,7 +468,7 @@ def merge_shuffle(sources, out_dir, max_eval_sentences=5000, remove_duplicates=T
     def write_lines():
         with open(os.path.join(out_dir, "src.txt"), "w", encoding="utf-8") as src, \
              open(os.path.join(out_dir, "tgt.txt"), "w", encoding="utf-8") as tgt:
-             while True:
+            while True:
                 count = len(lines)
                 if count > 0:
                     sbuf = StringIO()

--- a/data.py
+++ b/data.py
@@ -14,130 +14,203 @@ from removedup import rdup
 from fastshuffle import file_shuffle_sample
 from io import StringIO
 
-nllb_langs = {
-    "af":"afr_Latn",
-    "ak":"aka_Latn",
-    "am":"amh_Ethi",
-    "ar":"arb_Arab",
-    "as":"asm_Beng",
-    "ay":"ayr_Latn",
-    "az":"azj_Latn",
-    "bm":"bam_Latn",
-    "be":"bel_Cyrl",
-    "bn":"ben_Beng",
-    "bho":"bho_Deva",
-    "bs":"bos_Latn",
-    "bg":"bul_Cyrl",
-    "ca":"cat_Latn",
-    "ceb":"ceb_Latn",
-    "cs":"ces_Latn",
-    "ckb":"ckb_Arab",
-    "tt":"crh_Latn",
-    "cy":"cym_Latn",
-    "da":"dan_Latn",
-    "de":"deu_Latn",
-    "el":"ell_Grek",
-    "en":"eng_Latn",
-    "eo":"epo_Latn",
-    "et":"est_Latn",
-    "eu":"eus_Latn",
-    "ee":"ewe_Latn",
-    "fa":"pes_Arab",
-    "fi":"fin_Latn",
-    "fr":"fra_Latn",
-    "gd":"gla_Latn",
-    "ga":"gle_Latn",
-    "gl":"glg_Latn",
-    "gn":"grn_Latn",
-    "gu":"guj_Gujr",
-    "ht":"hat_Latn",
-    "ha":"hau_Latn",
-    "he":"heb_Hebr",
-    "hi":"hin_Deva",
-    "hr":"hrv_Latn",
-    "hu":"hun_Latn",
-    "hy":"hye_Armn",
-    "nl":"nld_Latn",
-    "ig":"ibo_Latn",
-    "ilo":"ilo_Latn",
-    "id":"ind_Latn",
-    "is":"isl_Latn",
-    "it":"ita_Latn",
-    "jv":"jav_Latn",
-    "ja":"jpn_Jpan",
-    "kn":"kan_Knda",
-    "ka":"kat_Geor",
-    "kk":"kaz_Cyrl",
-    "km":"khm_Khmr",
-    "rw":"kin_Latn",
-    "ko":"kor_Hang",
-    "ku":"kmr_Latn",
-    "lo":"lao_Laoo",
-    "lv":"lvs_Latn",
-    "ln":"lin_Latn",
-    "lt":"lit_Latn",
-    "lb":"ltz_Latn",
-    "lg":"lug_Latn",
-    "lus":"lus_Latn",
-    "mai":"mai_Deva",
-    "ml":"mal_Mlym",
-    "mr":"mar_Deva",
-    "mk":"mkd_Cyrl",
-    "mg":"plt_Latn",
-    "mt":"mlt_Latn",
-    "mni-Mtei":"mni_Beng",
-    "mni":"mni_Beng",
-    "mn":"khk_Cyrl",
-    "mi":"mri_Latn",
-    "ms":"zsm_Latn",
-    "my":"mya_Mymr",
-    "no":"nno_Latn",
-    "ne":"npi_Deva",
-    "ny":"nya_Latn",
-    "om":"gaz_Latn",
-    "or":"ory_Orya",
-    "pl":"pol_Latn",
-    "pt":"por_Latn",
-    "ps":"pbt_Arab",
-    "qu":"quy_Latn",
-    "ro":"ron_Latn",
-    "ru":"rus_Cyrl",
-    "sa":"san_Deva",
-    "si":"sin_Sinh",
-    "sk":"slk_Latn",
-    "sl":"slv_Latn",
-    "sm":"smo_Latn",
-    "sn":"sna_Latn",
-    "sd":"snd_Arab",
-    "so":"som_Latn",
-    "es":"spa_Latn",
-    "sq":"als_Latn",
-    "sr":"srp_Cyrl",
-    "su":"sun_Latn",
-    "sv":"swe_Latn",
-    "sw":"swh_Latn",
-    "ta":"tam_Taml",
-    "te":"tel_Telu",
-    "tg":"tgk_Cyrl",
-    "tl":"tgl_Latn",
-    "th":"tha_Thai",
-    "ti":"tir_Ethi",
-    "ts":"tso_Latn",
-    "tk":"tuk_Latn",
-    "tr":"tur_Latn",
-    "ug":"uig_Arab",
-    "uk":"ukr_Cyrl",
-    "ur":"urd_Arab",
-    "uz":"uzn_Latn",
-    "vi":"vie_Latn",
-    "xh":"xho_Latn",
-    "yi":"ydd_Hebr",
-    "yo":"yor_Latn",
-    "zh-CN":"zho_Hans",
-    "zh":"zho_Hans",
-    "zh-TW":"zho_Hant",
-    "zu":"zul_Latn",
-    "pa":"pan_Guru"
+# The list is ordered according to lang_codes found on OPUS
+# Some dialects and scripts listed in flores200 have not been mapped due to lack of resource on OPUS
+nllb_langs = { #Name found on opus as comments, if [] other known alias, () several charsets
+    "ace":"ace_Latn", #Achinese
+    "af":"afr_Latn", #Afrikaans
+    "ak":"aka_Latn", #Akan
+    "am":"amh_Ethi", #Amharic
+    "ar":"arb_Arab", #Arabic
+    "as":"asm_Beng", #Assamese
+    "ast":"ast_Latn", #Asturian
+    "ay":"ayr_Latn", #Aymara
+    "az":"azj_Latn", #Azerbaijani (Latin)
+    "azb":"azb_Arab", #Azerbaijani (Arabic)
+    "ba":"bak_Cyrl", #Bashkir
+    "bm":"bam_Latn", #Bambara
+    "ban":"ban_Latn", #Balinese
+    "be":"bel_Cyrl", #Belarusian
+    "bem":"bem_Latn", #Bemba
+    "bn":"ben_Beng", #Bangla [Bengalese]
+    "bho":"bho_Deva", #Bhojpuri [Bihari]
+    "bjn":"bjn_Latn", #Banjar
+    "bo":"bod_Tibt", #Tibetan
+    "bs":"bos_Latn", #Bosnian
+    "bug":"bug_Latn", #Buginese
+    "bg":"bul_Cyrl", #Bulgarian
+    "ca":"cat_Latn", #Catalan
+    "ceb":"ceb_Latn", #Cebuano
+    "cs":"ces_Latn", #Czech
+    "cjk":"cjk_Latn", #Chokwe
+    "ckb":"ckb_Arab", #Central Kurdish [Sorani], no NLLB resource
+    "crh":"crh_Latn", #Crimean Tatar
+    "cy":"cym_Latn", #Welsh
+    "da":"dan_Latn", #Danish
+    "de":"deu_Latn", #German
+    "dik":"dik_Latn", #Dinka
+    "dyu":"dyu_Latn", #Dyula
+    "dz":"dzo_Tibt", #Dzongkha
+    "el":"ell_Grek", #Greek
+    "en":"eng_Latn", #English
+    "eo":"epo_Latn", #Esperanto
+    "es":"spa_Latn", #Spanish
+    "et":"est_Latn", #Estonian
+    "eu":"eus_Latn", #Basque
+    "ee":"ewe_Latn", #Ewe
+    "fa":"pes_Arab", #Persian
+    "fi":"fin_Latn", #Finnish
+    "ff":"fuv_Latn", #Fula [Nigerian Fulfulde]
+    "fj":"fij_Latn", #Fijian
+    "fo":"fao_Latn", #Faroese
+    "fon":"fon_Latn", #Fon
+    "fr":"fra_Latn", #French
+    "fur":"fur_Latn", #Friulian
+    "gd":"gla_Latn", #Scottish Gaelic
+    "ga":"gle_Latn", #Irish
+    "gl":"glg_Latn", #Galician
+    "gn":"grn_Latn", #Guarani
+    "gu":"guj_Gujr", #Gujarati
+    "ht":"hat_Latn", #Haitian Creole
+    "ha":"hau_Latn", #Hausa
+    "he":"heb_Hebr", #Hebrew
+    "hi":"hin_Deva", #Hindi
+    "hne":"hne_Deva", #Chhattishgarhi
+    "hr":"hrv_Latn", #Croatian
+    "hu":"hun_Latn", #Hungarian
+    "hy":"hye_Armn", #Armenian
+    "ig":"ibo_Latn", #Igbo
+    "ilo":"ilo_Latn", #Iloko [Ilocano]
+    "id":"ind_Latn", #Indonesian
+    "is":"isl_Latn", #Icelandic
+    "it":"ita_Latn", #Italian
+    "jv":"jav_Latn", #Javanese
+    "ja":"jpn_Jpan", #Japanese
+    "kn":"kan_Knda", #Kannada
+    "ka":"kat_Geor", #Georgian [Kartvelian]
+    "kab":"kab_latn", #Kabyle [Berber/Tamazight] (Latin)
+    "kac":"kac_Latn", #Kachin
+    "kam":"kam_Latn", #Kamba
+    "kbp":"kbp_Latn", #Kabiye
+    "kea":"kea_Latn", #Kabuverdianu
+    "kg":"kon_Latn", #Kongo
+    "ki":"kik_Latn", #Kikuyu
+    "kk":"kaz_Cyrl", #Kazakh
+    "km":"khm_Khmr", #Khmer
+    "kmb":"kmb_Latn", #Kimbundu
+    "ko":"kor_Hang", #Korean
+    "ks-Arab":"kas_Arab", #Kashmiri (Arabic)
+    "ks-Deva":"kas_Deva", #Kashmiri (Devanagari)
+    "kr-Arab":"knc_Arab", #Kanuri (Arabic)
+    "kr-Latn":"knc_Latn", #Kanuri (Latin)
+    "ku":"kmr_Latn", #Kurdish [Kurmandji], small corpora, NLLB resource under "ku-Latn"
+    "ku-Latn":"kmr_Latn", #Kurdish, NLLB resource in ku-en (also NLLB ku-ar in kmr_Arab under ku-Arab)
+    "ky":"kir_Cyrl", #Kyrgyz
+    "lb":"ltz_Latn", #Luxembourgish
+    "lg":"lug_Latn", #Ganda
+    "li":"lim_Latn", #Limburgish
+    "lij":"lij_Latn", #Ligurian
+    "lmo":"lmo_Latn", #Lombard
+    "ln":"lin_Latn", #Lingala
+    "lo":"lao_Laoo", #Laotian
+    "lt":"lit_Latn", #Lithuanian
+    "ltg":"ltg_Latn", #Latgalian
+    "lua":"lua_Latn", #Luba-Lulua
+    "luo":"luo_Latn", #Luo
+    "lus":"lus_Latn", #Mizo
+    "lv":"lvs_Latn", #Latvian
+    "mag":"mag_Deva", #Magahi
+    "mai":"mai_Deva", #Maithili
+    "min-Arab":"min_Arab", #Minangkabau (Arabic), no NLLB resource
+    "min":"min_Latn", #Minangkabau
+    "mg":"plt_Latn", #Malagasy
+    "mi":"mri_Latn", #Maori
+    "mk":"mkd_Cyrl", #Macedonian
+    "ml":"mal_Mlym", #Malayalam
+    "mn":"khk_Cyrl", #Mongolian
+    "mni":"mni_Beng", #Manipuri
+    "mos": "mos_Latn", #Mossi
+    "mr":"mar_Deva", #Marathi
+    "ms":"zsm_Latn", #Malay
+    "mt":"mlt_Latn", #Maltese
+    "my":"mya_Mymr", #Burmese
+    "nb":"nob_Latn", #Norwegian Bokmål, PAracrawl/HPLT/ELRC resources
+    "ne":"npi_Deva", #Nepalese
+    "nl":"nld_Latn", #Dutch
+    "nn":"nno_Latn", #Norwegian Nynorsk, no NLLB resource
+    "no":"nob_Latn", #Norwegian [Bokmål]
+    "nso":"nso_Latn", #Northern Sotho
+    "nus":"nus_Latn", #Nuer
+    "ny":"nya_Latn", #Nyanja [Chichewa]
+    "oc":"oci_Latn", #Occitan
+    "om":"gaz_Latn", #Oromo
+    "or":"ory_Orya", #Odia [Oriya/Odiya]
+    "pag":"pag_Latn", #Pangasinan
+    "pa":"pan_Guru", #Panjabi
+    "pap":"pap_Latn", #Papiamento
+    "pl":"pol_Latn", #Polish
+    "prs":"prs_Arab", #Dari
+    "ps":"pbt_Arab", #Pashto
+    "pt":"por_Latn", #Portuguese
+    "qu":"quy_Latn", #Quechua
+    "rn":"run_Latn", #Rundi [Kirundi]
+    "ro":"ron_Latn", #Romanian
+    "ru":"rus_Cyrl", #Russian
+    "rw":"kin_Latn", #Kinyarwanda
+    "sa":"san_Deva", #Sanskrit
+    "sat":"sat_Olck", #Santali
+    "sc":"srd_Latn", #Sardinian
+    "scn":"scn_Latn", #Sicilian
+    "sd":"snd_Arab", #Sindhi
+    "sg":"sag_Latn", #Sango
+    "shn":"shn_Mymr", #Shan
+    "si":"sin_Sinh", #Sinhalese
+    "sk":"slk_Latn", #Slovak
+    "sl":"slv_Latn", #Slovenian
+    "sm":"smo_Latn", #Samoan
+    "sn":"sna_Latn", #Shona
+    "so":"som_Latn", #Somali
+    "sq":"als_Latn", #Albanian
+    "sr":"srp_Cyrl", #Serbian
+    "ss":"ssw_Latn", #Swati [siSwati]
+    "st":"sot_Latn", #Sotho [seSotho]
+    "su":"sun_Latn", #Sundanese
+    "sv":"swe_Latn", #Swedish
+    "sw":"swh_Latn", #Swahili
+    "szl":"szl_Latn", #Silesian
+    "ta":"tam_Taml", #Tamil
+    "taq":"taq_Latn", #Tamasheq [Tuareg]
+    "te":"tel_Telu", #Telugu
+    "tg":"tgk_Cyrl", #Tajik
+    "th":"tha_Thai", #Thai
+    "ti":"tir_Ethi", #Tigrinya
+    "tk":"tuk_Latn", #Turkmen
+    "tl":"tgl_Latn", #Filipino [Tagalog]
+    "tn":"tsn_Latn", #Tswana
+    "tpi":"tpi_Latn", #Tok Pisin
+    "tr":"tur_Latn", #Turkish
+    "ts":"tso_Latn", #Tsonga
+    "tt":"tat_Cyrl", #Tatar
+    "tum":"tum_Latn", #Tumbuka
+    "tw":"twi_Latn", #Twi/Akan
+    "tzm":"tzm_Tfng", #Central Atlas Tamazight (Tifinagh)
+    "ug":"uig_Arab", #Uighur
+    "uk":"ukr_Cyrl", #Ukrainian
+    "umb":"umb_Latn", #Umbundu [Kimbundu]
+    "ur":"urd_Arab", #Urdu
+    "uz":"uzn_Latn", #Uzbek
+    "vec":"vec_Latn", #Venetian
+    "vi":"vie_Latn", #Vietnamese
+    "war":"war_Latn", #Waray
+    "wo":"wol_Latn", #Wolof
+    "xh":"xho_Latn", #Xhosa
+    "yi":"ydd_Hebr", #Yiddish
+    "yo":"yor_Latn", #Yoruba
+    "yue":"yue_Hant", #Yue chinese [Cantonese], no NLLB resource
+    "zh-CN":"zho_Hans", #Chinese (Simplified), no NLLB resource
+    "zh":"zho_Hans", #Chinese (Simplified)
+    "zh-TW":"zho_Hant", #Chinese (Traditional)
+    "zu":"zul_Latn" #Zulu
 }
 
 def count_lines(file):

--- a/data.py
+++ b/data.py
@@ -241,13 +241,15 @@ def sources_changed(sources, out_dir):
     return True
 
 def get_flores_dataset_path(dataset="dev"):
-    if dataset != "dev" and dataset != "devtest":
-        print(f"Invalid dataset {dataset} (must be either dev or devtest)")
-        exit(1)
+    # Swap the definitions to allow looking for translation memoirs
     current_dir = os.path.dirname(__file__)
     utils_dir = os.path.join(current_dir, "utils")
-
     flores_dataset = os.path.join(utils_dir, "flores200_dataset", dataset)
+
+    if dataset != "dev" and dataset != "devtest" and not os.path.isdir(flores_dataset):
+        print(f"Invalid dataset {dataset} (must be either dev, devtest), or a valid translation memoir.")
+        exit(1)
+
     if not os.path.isdir(flores_dataset):
         os.makedirs(utils_dir, exist_ok=True)
     
@@ -278,7 +280,9 @@ def get_flores_file_path(lang_code, dataset="dev"):
 def get_flores(lang_code, dataset="dev"):
     flores_dataset = get_flores_dataset_path(dataset)
     source = os.path.join(flores_dataset, nllb_langs[lang_code] + f".{dataset}")
-
+    if not os.path.isfile(source) and dataset != "dev" and dataset != "devtest":
+        print(f"The memoir version for {lang_code} is missing or should be renamed {nllb_langs[lang_code]}.{dataset}")
+        exit(1)
     vs = [line.rstrip('\n') for line in open(source, encoding="utf-8")]
     return vs
 

--- a/data.py
+++ b/data.py
@@ -172,27 +172,27 @@ def get_flores_dataset_path(dataset="dev"):
         print(f"Invalid dataset {dataset} (must be either dev or devtest)")
         exit(1)
     current_dir = os.path.dirname(__file__)
-    cache_dir = os.path.join(current_dir, "cache")
+    utils_dir = os.path.join(current_dir, "utils")
 
-    flores_dataset = os.path.join(cache_dir, "flores200_dataset", dataset)
+    flores_dataset = os.path.join(utils_dir, "flores200_dataset", dataset)
     if not os.path.isdir(flores_dataset):
-        os.makedirs(cache_dir, exist_ok=True)
+        os.makedirs(utils_dir, exist_ok=True)
     
         # Download first
         print("Downloading flores200 dataset...")
-        fname = os.path.join(cache_dir, "flores200.tar.gz")
+        fname = os.path.join(utils_dir, "flores200.tar.gz")
         flores_url = "https://tinyurl.com/flores200dataset"
-        download(flores_url, cache_dir, basename=os.path.basename(fname))
+        download(flores_url, utils_dir, basename=os.path.basename(fname))
 
         import tarfile
         with tarfile.open(fname) as f:
-            f.extractall(cache_dir)
+            f.extractall(utils_dir)
         
         if os.path.isfile(fname):
             os.unlink(fname)
 
         if not os.path.isdir(flores_dataset):
-            print(f"Cannot download flores200. Please manually download it from {flores_url} and place it in {cache_dir}")
+            print(f"Cannot download flores200. Please manually download it from {flores_url} and place it in {utils_dir}")
             exit(1)
 
     return flores_dataset

--- a/eval.py
+++ b/eval.py
@@ -88,10 +88,10 @@ if args.pivot:
             print(f"Pivoting to {args.pivot} using {subdir}.")
             pivot_to = True
     if pivot_from and pivot_to:
-        print('Pivot is ambiguous: delete the models not needed for pivoting from "utils".')
+        print('Pivot is ambiguous: delete the model not needed for this pivot from "utils".')
         exit(1)
     if not pivot_from and not pivot_to:
-        print('No valid model for pivot. Switch off pivot or unzip the model into "utils".')
+        print('No valid model for pivot: unzip the pivot Argos package into "utils".')
         exit(1)
 
 def pivot_translator():

--- a/eval.py
+++ b/eval.py
@@ -36,6 +36,9 @@ parser.add_argument('--translate_flores',
 parser.add_argument('--comet',
     action="store_true",
     help='Run COMET score command on the translated flores text. Default: %(default)s')
+parser.add_argument('--pivot',
+    type=str,
+    help='Applies a pivotal translation from or to another language and evaluates the composite translation.')
 parser.add_argument('--cpu',
     action="store_true",
     help='Force CPU use. Default: %(default)s')
@@ -63,10 +66,39 @@ run_dir = os.path.join(current_dir, "run", model_dirname)
 ct2_model_dir = os.path.join(run_dir, "model")
 sp_model = os.path.join(run_dir, "sentencepiece.model")
 bpe_model = os.path.join(run_dir, "bpe.model")
+pivot_from, pivot_to = False, False
 
 if not os.path.isdir(ct2_model_dir) or (not os.path.isfile(sp_model) and not os.path.isfile(bpe_model)):
     print(f"The model in {run_dir} is not valid. Did you run train.py first?")
     exit(1)
+if args.pivot:
+    utils_subdir = [dir for dir in os.listdir(utils_dir) if os.path.isdir(os.path.join(utils_dir, dir))]
+
+    for subdir in utils_subdir:
+        if (f"{args.pivot}_{config['from']['code']}") in subdir:
+            pivot_dir = os.path.join(utils_dir, subdir)
+            ct2_pivot_dir = os.path.join(pivot_dir, "model")
+            sp_pivot = os.path.join(pivot_dir, "sentencepiece.model")
+            print(f"Pivoting from {args.pivot} using {subdir}.")
+            pivot_from = True
+        if (f"{config['to']['code']}_{args.pivot}") in subdir:
+            pivot_dir = os.path.join(utils_dir, subdir)
+            ct2_pivot_dir = os.path.join(pivot_dir, "model")
+            sp_pivot = os.path.join(pivot_dir, "sentencepiece.model")
+            print(f"Pivoting to {args.pivot} using {subdir}.")
+            pivot_to = True
+    if pivot_from and pivot_to:
+        print('Pivot is ambiguous: delete the models not needed for pivoting from "utils".')
+        exit(1)
+    if not pivot_from and not pivot_to:
+        print('No valid model for pivot. Switch off pivot or unzip the model into "utils".')
+        exit(1)
+
+def pivot_translator():
+    device = "cuda" if ctranslate2.get_cuda_device_count() > 0 and not args.cpu else "cpu"
+    model = ctranslate2.Translator(ct2_pivot_dir, device=device, compute_type="default")
+    tokenizer = SentencePieceTokenizer(sp_pivot)
+    return {"model": model, "tokenizer": tokenizer}
 
 
 def translator():
@@ -85,13 +117,15 @@ def decode(tokens, tokenizer):
     if args.tokens:
         return " ".join(tokens)
     else:
-        detokenized = tokenizer.decode(tokens)
-        if len(detokenized) > 0 and detokenized[0] == " ":
-            detokenized = detokenized[1:]
-        return detokenized
+        return tokenizer.decode(tokens)
 
 def translate_flores():
-    tra_filename = f"flores200{dataset}-{model_dirname}.evl"
+    if args.pivot and pivot_from:
+        tra_filename = f"flores200{dataset}-{args.pivot}_{model_dirname}.evl"
+    elif args.pivot and pivot_to:
+        tra_filename = f"flores200{dataset}-{config['from']['code']}_{config['to']['code']}_{args.pivot}-{config['version']}.evl"
+    else:
+        tra_filename = f"flores200{dataset}-{model_dirname}.evl"
     tra_f = os.path.join(run_dir, tra_filename)
     with open(tra_f, "w", encoding="utf8") as translation_file:
         for t in translated_text:
@@ -111,6 +145,23 @@ if args.bleu or args.flores_id or args.translate_flores or args.comet is not Non
         src_text = [src_text[args.flores_id]]
         tgt_text = [tgt_text[args.flores_id]]
 
+    if args.pivot and pivot_from:
+        src_text = get_flores(args.pivot, dataset)
+        pivot = pivot_translator()
+        pivot_obj = pivot["model"].translate_batch(
+            [encode(t, pivot["tokenizer"]) for t in src_text],
+            beam_size=4,  # same as argos
+            return_scores=False,  # speed up,
+            max_batch_size=args.max_batch_size,
+        )
+
+        pivoted_text = [
+            decode(tokens.hypotheses[0], pivot["tokenizer"])
+            for tokens in pivot_obj
+        ]
+
+        src_text = pivoted_text
+
     translation_obj = data["model"].translate_batch(
         [encode(t, data["tokenizer"]) for t in src_text],
         beam_size=4, # same as argos
@@ -122,7 +173,24 @@ if args.bleu or args.flores_id or args.translate_flores or args.comet is not Non
         decode(tokens.hypotheses[0], data["tokenizer"])
         for tokens in translation_obj
     ]
-    
+
+    if args.pivot and pivot_to:
+        tgt_text = get_flores(args.pivot, dataset)
+        pivot = pivot_translator()
+        pivot_obj = pivot["model"].translate_batch(
+            [encode(t, pivot["tokenizer"]) for t in translated_text],
+            beam_size=4,  # same as argos
+            return_scores=False,  # speed up,
+            max_batch_size=args.max_batch_size,
+        )
+
+        pivoted_text = [
+            decode(tokens.hypotheses[0], pivot["tokenizer"])
+            for tokens in pivot_obj
+        ]
+
+        translated_text = pivoted_text
+
     bleu_score = round(corpus_bleu(
         translated_text, [[x] for x in tgt_text]
     ).score, 5)
@@ -131,8 +199,14 @@ if args.bleu or args.flores_id or args.translate_flores or args.comet is not Non
         translate_flores()
 
     if args.comet:
-        src_f = get_flores_file_path(config["from"]["code"], dataset)
-        ref_f = get_flores_file_path(config["to"]["code"], dataset)
+        if args.pivot and pivot_from:
+            src_f = get_flores_file_path(args.pivot, dataset)
+        else:
+            src_f = get_flores_file_path(config["from"]["code"], dataset)
+        if args.pivot and pivot_to:
+            ref_f = get_flores_file_path(args.pivot, dataset)
+        else:
+            ref_f = get_flores_file_path(config["to"]["code"], dataset)
         tra_f = translate_flores()
         
         subprocess.run([

--- a/eval.py
+++ b/eval.py
@@ -57,7 +57,7 @@ except Exception as e:
     exit(1)
 
 current_dir = os.path.dirname(__file__)
-cache_dir = os.path.join(current_dir, "cache")
+utils_dir = os.path.join(current_dir, "utils")
 model_dirname = f"{config['from']['code']}_{config['to']['code']}-{config['version']}"
 run_dir = os.path.join(current_dir, "run", model_dirname)
 ct2_model_dir = os.path.join(run_dir, "model")

--- a/filters.py
+++ b/filters.py
@@ -116,4 +116,10 @@ def first_char_mismatch(src, tgt):
         return True
     else:
         return src[0] != tgt[0]
-    
+
+def fast_lang(src, tgt, s_lang, t_lang, model):
+    """
+    Removes lines when the languages detected using fasttext language identification differ from those specified in config.
+    """
+    return s_lang != model.predict(src)[0][0].replace("__label__", '') or \
+       t_lang != model.predict(tgt)[0][0].replace("__label__", '')

--- a/filters.py
+++ b/filters.py
@@ -123,3 +123,23 @@ def fast_lang(src, tgt, s_lang, t_lang, model):
     """
     return s_lang != model.predict(src)[0][0].replace("__label__", '') or \
        t_lang != model.predict(tgt)[0][0].replace("__label__", '')
+
+def limit_latin_chars(src, tgt, s_chset, t_chset, max = 12):
+    """
+    Removes lines with more than "max" latin characters when language uses other alphabet.
+    Max = 12 retains most named entities and acronyms.
+    For emails, reinject filtered data with max value at 20-30
+    """
+    def latin_char_count(sent):
+        count = 0
+        latin_set = set('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+        for ch in sent:
+            if ch in latin_set:
+                count +=1
+        return count
+    if s_chset != "Latn":
+        return latin_char_count(src) > max
+    elif t_chset != "Latn":
+        return latin_char_count(tgt) > max
+    else:
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ torch==2.0.1+cu117 ; sys_platform == 'linux' or sys_platform == 'win32'
 torch==2.0.1 ; sys_platform == 'darwin'
 ctranslate2==3.20.0
 stanza==1.1.1
+spacy
 sentencepiece==0.1.99
 requests==2.32.2
 PyYAML==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ torch==2.0.1 ; sys_platform == 'darwin'
 ctranslate2==3.20.0
 stanza==1.1.1
 sentencepiece==0.1.99
-requests==2.31.0
+requests==2.32.2
 PyYAML==6.0.1
 sacrebleu==2.3.1
 unbabel-comet==2.2.2

--- a/sbd.py
+++ b/sbd.py
@@ -1,0 +1,104 @@
+import os
+import shutil
+import stanza
+import spacy
+from spacy.cli import download
+
+'''
+This module deals with sentence boundary detection packages:
+As per last Argos PR, you may have a language-specific Spacy package (light and efficient);
+a Stanza package is useful when the former requires a third-party dependency or does not exist;
+then, when none of the above is available, Argos uses cached/shared spacy multilingual.
+'''
+
+def package_sbd(run_dir, lang_code):
+    stanza_dir = os.path.join(run_dir, "stanza")
+    spacy_dir = os.path.join(run_dir, "spacy")
+    spacy_utils = os.path.join(os.path.dirname(__file__), "utils", "spacy")
+    spacy_lang_utils = os.path.join(os.path.dirname(__file__), "utils", f'spacy_{lang_code}')
+
+    # First, a list of ===third-dependency-free=== spacy packages (feel free to update)
+    # ja, ko, ru, th, uk, vi & zh require external dependencies, each package+dependencies > 70Mo (stanza better)
+    spacy_models = {
+        "ca": "ca_core_news_sm",
+        "da": "da_core_news_sm",
+        "de": "de_core_news_sm",
+        "el": "el_core_news_sm",
+        "en": "en_core_web_sm",
+        "es": "es_core_news_sm",
+        "fi": "fi_core_news_sm",
+        "fr": "fr_core_news_sm",
+        "hr": "hr_core_news_sm",
+        "it": "it_core_news_sm",
+        "lt": "lt_core_news_sm",
+        "mk": "mk_mk_news_sm",
+        "nb": "nb_core_news_sm",
+        "nl": "nl_core_news_sm",
+        "no": "nb_core_news_sm",
+        "pl": "pl_core_news_sm",
+        "pt": "pt_core_news_sm",
+        "ro": "ro_core_news_sm",
+        "sl": "sl_core_news_sm",
+        'sv': 'sv_core_news_sm',
+    }
+    '''
+    Writing a dummy file is a necessary evil: a symlink will package spacy xx at end of training
+    Plus, on Windows, it requires activating Settings/System/Developer mode, that's not always policy.
+    '''
+    if os.path.isfile(os.path.join(spacy_dir, "senter", "model")):
+        print('spaCy library ready')
+        return spacy_dir
+    elif os.path.isdir(os.path.join(stanza_dir, lang_code)):
+        print('Stanza library ready')
+        return stanza_dir
+    elif os.path.isfile(spacy_dir): #Dummy file
+        print('spaCy multilingual library in utils.')
+        return spacy_dir
+    else:
+        # There may be a third-party-dependency-free Spacy library for this language
+        if lang_code in spacy_models:
+            try:
+                # Download once (verbosissimo) and use files from utils after
+                if not os.path.isfile(os.path.join(spacy_lang_utils, "senter", "model")):
+                    spacy.cli.download(spacy_models[lang_code])
+                    # Make it as lightweight as possible by excluding all unnecessary functions
+                    nlp = spacy.load(spacy_models[lang_code], exclude=("parser", "tagger", "lemmatizer", "morphologizer",
+                                                                      "ner", "tok2vec", "attribute_ruler"))
+                    nlp.to_disk(spacy_lang_utils)
+                    print('Language-specific Spacy model written to utils.')
+                shutil.copytree(spacy_lang_utils,spacy_dir)
+                print('Packaged spaCy model ready.')
+                return spacy_dir
+            except Exception as e:
+                print(f'{str(e)}.')
+        # Then there is Stanza: we'll take legacy download, strip the while True loop, it doesn't seem to add much
+        else:
+            try:
+                os.makedirs(stanza_dir, exist_ok=True)
+                stanza.download(lang_code, dir=stanza_dir, processors="tokenize")
+                return stanza_dir
+            except Exception as e:
+                # Then spacy multilingual
+                if str(e).startswith('Unsupported language'):
+                    print(f'Stanza said: " {str(e)}"; hence, will use spacy multilingual.')
+                    os.remove(os.path.join(stanza_dir, "resources.json"))
+                    os.rmdir(stanza_dir)
+                    # Avoid verbose download
+                    if not os.path.isfile(os.path.join(spacy_utils, "senter", "model")):
+                        try:
+                            spacy.cli.download("xx_sent_ud_sm")
+                            print(f'Downloaded multilingual spaCy model. Loading and writing to utils.')
+                            nlp = spacy.load("xx_sent_ud_sm", exclude="parser")
+                            nlp.to_disk(spacy_utils)
+                            print('Multilingual spaCy model written to utils.')
+                        except Exception as e:
+                            print(f'{str(e)}.')
+                            exit(1)
+                    # Writes a dummy file and returns None, otherwise will package the cached model.
+                    with open(spacy_dir, "w", encoding="utf-8") as dummy:
+                        dummy.write('spaCy multilingual in utils.')
+                    print('Multilingual spaCy model in utils: wrote dummy file.')
+                    return spacy_dir
+                else:
+                    print(f'{str(e)}.')
+                    exit(1)

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -24,8 +24,7 @@ class SentencePieceTokenizer(Tokenizer):
         return tokens
 
     def decode(self, tokens: List[str]) -> str:
-        detokenized = "".join(tokens)
-        return detokenized.replace("▁", " ")
+        return self.lazy_processor().decode_pieces(tokens).replace("▁", " ")
 
 
 class BPETokenizer(Tokenizer):

--- a/train.py
+++ b/train.py
@@ -281,7 +281,7 @@ onmt_config = {
     'src_vocab': f"{rel_onmt_dir}/openmt.vocab",
     'tgt_vocab': f"{rel_onmt_dir}/openmt.vocab",
     'src_vocab_size': config.get('vocab_size', 50000), #default onmt value: 32768
-    'tgt_vocab_size': config.get('vocab_size', 50000), #same as latter
+    'tgt_vocab_size': config.get('vocab_size', 50000), #same as former
     'share_vocab': True, 
     'data': corpora, 
     'src_subword_type': 'sentencepiece',
@@ -333,7 +333,7 @@ onmt_config = {
     'normalization': 'tokens', 
     'encoder_type': 'transformer', 
     'decoder_type': 'transformer', 
-    'position_encoding': True, #onmt default, FAlse for relative [Shaw] and rotative  [RoPE] position encoding
+    'position_encoding': True, #onmt default, False for relative [Shaw] and rotative  [RoPE] position encoding
     'max_relative_positions': 0, #onmt default, 20 and 32 will do Shaw, -1 will do RoPE
 	'pos_ffn_activation_fn': 'relu', #to use "gated-gelu" or "silu", modify the CTranslate2 converter
     'enc_layers': 6, 

--- a/train.py
+++ b/train.py
@@ -127,7 +127,9 @@ for s in config['sources']:
                 source, target = target, source
             sources[s] = {
                 'source': source,
+                'from': config['from']['code'],
                 'target': target,
+                'to': config['to']['code'],
                 'hash': md5,
                 'filters': filters,
                 'transforms': transforms,

--- a/train.py
+++ b/train.py
@@ -69,6 +69,7 @@ readme = f"# {config['from']['name']} - {config['to']['name']} version {config['
 
 current_dir = os.path.dirname(__file__)
 cache_dir = os.path.join(current_dir, "cache")
+utils_dir = os.path.join(current_dir, "utils")
 model_dirname = f"{config['from']['code']}_{config['to']['code']}-{config['version']}"
 run_dir = os.path.join(current_dir, "run", model_dirname)
 onmt_dir = os.path.join(run_dir, "opennmt")
@@ -76,6 +77,7 @@ stanza_dir = os.path.join(run_dir, "stanza")
 rel_run_dir = f"run/{model_dirname}"
 rel_onmt_dir = f"{rel_run_dir}/opennmt"
 os.makedirs(cache_dir, exist_ok=True)
+os.makedirs(utils_dir, exist_ok=True)
 
 if args.rerun and os.path.isdir(run_dir):
     shutil.rmtree(run_dir)


### PR DESCRIPTION
1. New "utils" dir includes flores200_dataset dir 
2. Update and edits to NLLB languages list
3. Paste translation memoirs in flores200_dataset dir (in a {dataset} subdir as {nllb_langs[lang_code]}.{dataset} files)
4. Tokenizer with byte-fallback (courtesy of @lynxpda), fix vulnerability in requests dependency
5. Enabling research on advanced transformers (positional encoding, activation, ... please read comments)
6. Evaluate composite translation with --pivot argument in eval
7. Versatile SBD as per argos-translate PR#460 (Packaged spaCy -"en", "fr", "de", etc., Stanza, or spaCy "xx" cached)
8. "fast_lang" filter running with fasttext 176.lid.bin (implementation in FILTERS.md)
9. "limit_latin_chars" filter, typos in train comments from 5.
10. edits in error messages and README statement from 6.