### PR TITLE
Update opus_mt_convert.py

### DIFF
--- a/opus_mt_convert.py
+++ b/opus_mt_convert.py
@@ -205,7 +205,9 @@ stanza_remap = {
     "bn": "hi",
     "ms": "en",
     "tl": "en",
-    "pb": "pt"
+    "pb": "pt",
+    "br": "en",
+    "ber": "en"
 }
 if stanza_lang_code in stanza_remap:
     remapped = stanza_lang_code


### PR DESCRIPTION
Add breton `br` and berber (kabyle) `ber` fallback to english tokenizer.

This resolves the "no stanza availability" for both berber and brezhoneg (breton) languages.

`python opus_mt_convert.py -s ber -t en`

`python opus_mt_convert.py -s br -t en`